### PR TITLE
Fix user location display

### DIFF
--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -260,6 +260,10 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
 
 - (MKAnnotationView *)mapView:(__unused AIRMap *)mapView viewForAnnotation:(AIRMapMarker *)marker
 {
+    if (![marker isKindOfClass:[AIRMapMarker class]]) {
+        return nil;
+    }
+
     marker.map = mapView;
     return [marker getAnnotationView];
 }


### PR DESCRIPTION
It crashes because it receives a `MKUserLocation`.

```
2016-01-21 16:35:57.544 App[34016:4472995] -[MKUserLocation setMap:]: unrecognized selector sent to instance 0x7f8b83a2c5f0
2016-01-21 16:35:57.561 App[34016:4472995] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[MKUserLocation setMap:]: unrecognized selector sent to instance 0x7f8b83a2c5f0'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010a94df45 __exceptionPreprocess + 165
	1   libobjc.A.dylib                     0x00000001070b3deb objc_exception_throw + 48
	2   CoreFoundation                      0x000000010a95656d -[NSObject(NSObject) doesNotRecognizeSelector:] + 205
	3   CoreFoundation                      0x000000010a8a3eea ___forwarding___ + 970
	4   CoreFoundation                      0x000000010a8a3a98 _CF_forwarding_prep_0 + 120
	5   App                              0x0000000106c54ba7 -[AIRMapManager mapView:viewForAnnotation:] + 103
	6   MapKit                              0x000000010b8c89a1 -[MKMapView annotationManager:representationForAnnotation:] + 308
	7   MapKit                              0x000000010b936bf6 -[MKAnnotationManager _addRepresentationForAnnotation:] + 355
	8   MapKit                              0x000000010b9363be -[MKAnnotationManager updateVisibleAnnotations] + 1551
	9   MapKit                              0x000000010b8b8718 -[MKMapView _didChangeRegionMidstream:] + 232
	10  MapKit                              0x000000010b8bd35a -[MKMapView mapLayer:didChangeRegionAnimated:] + 81
	11  VectorKit                           0x000000011594d49a -[VKMapCameraController stopPinchingWithFocusPoint:] + 74
	12  MapKit                              0x000000010b90d3c8 __38-[MKMapGestureController handlePinch:]_block_invoke175 + 126
	13  UIKit                               0x0000000108b59196 __47+[_UIDynamicAnimation _updateAnimations:timer:]_block_invoke + 33
	14  CoreFoundation                      0x000000010a87ca42 __53-[__NSArrayM enumerateObjectsWithOptions:usingBlock:]_block_invoke + 114
	15  CoreFoundation                      0x000000010a87c132 -[__NSArrayM enumerateObjectsWithOptions:usingBlock:] + 194
	16  UIKit                               0x0000000108b58dc7 +[_UIDynamicAnimation _updateAnimations:timer:] + 79
	17  Foundation                          0x0000000107a39181 __NSFireTimer + 83
	18  CoreFoundation                      0x000000010a8ae264 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	19  CoreFoundation                      0x000000010a8ade11 __CFRunLoopDoTimer + 1089
	20  CoreFoundation                      0x000000010a86f821 __CFRunLoopRun + 1937
	21  CoreFoundation                      0x000000010a86ee08 CFRunLoopRunSpecific + 488
	22  GraphicsServices                    0x000000010d6a7ad2 GSEventRunModal + 161
	23  UIKit                               0x00000001083cb30d UIApplicationMain + 171
	24  App                              0x00000001069e395f main + 111
	25  libdyld.dylib                       0x000000010bcba92d start + 1
	26  ???                                 0x0000000000000001 0x0 + 1
```
