### PR TITLE
Only setRegion on layout once

### DIFF
--- a/components/MapView.js
+++ b/components/MapView.js
@@ -293,9 +293,11 @@ var MapView = React.createClass({
   _onLayout: function(e) {
     const { region, initialRegion, onLayout } = this.props;
     const { isReady } = this.state;
-    if (region && isReady) {
+    if (region && isReady && !this.__layoutCalled) {
+      this.__layoutCalled = true;
       this.refs.map.setNativeProps({ region });
-    } else if (initialRegion && isReady) {
+    } else if (initialRegion && isReady && !this.__layoutCalled) {
+      this.__layoutCalled = true;
       this.refs.map.setNativeProps({ region: initialRegion });
     }
     onLayout && onLayout(e);


### PR DESCRIPTION
Fixes #28 

In order to use the non-deprecated `getMapAsync` API on android, we had to add some code to set the region when the `onLayout` event gets fired.  Apparently Android 5.0 seems to call this event a LOT, where as other android versions don't, which was causing some jankiness. This code ensures that the region is only set on the first onLayout call.