### PR TITLE
passing style prop to AIRMap component

### DIFF
--- a/components/MapView.js
+++ b/components/MapView.js
@@ -372,7 +372,7 @@ var MapView = React.createClass({
     }
 
     return (
-      <AIRMap ref="map" {...props} />
+      <AIRMap style={this.props.style} ref="map" {...props} />
     );
   },
 });


### PR DESCRIPTION
I might be missing something but it seemed like the style prop wasn't being consumed anywhere so I couldn't do things like 

```
<MapView style={{flex: 1}} />
```