### PR TITLE
Potential fix for #77

### DIFF
--- a/android/src/main/java/com/AirMaps/AirMapMarker.java
+++ b/android/src/main/java/com/AirMaps/AirMapMarker.java
@@ -239,6 +239,7 @@ public class AirMapMarker extends AirMapFeature {
     @Override
     public void removeFromMap(GoogleMap map) {
         marker.remove();
+        marker = null;
     }
 
     private BitmapDescriptor getIcon() {


### PR DESCRIPTION
#77 
set marker as null once it's removed from the map

Not yet sure if there are situations where a marker is removed from and then re-added to the map.