### PR TITLE
android: use camera target instead of region center for onRegionUpdate lat/lng

### DIFF
--- a/android/src/main/java/com/AirMaps/AirMapView.java
+++ b/android/src/main/java/com/AirMaps/AirMapView.java
@@ -172,8 +172,9 @@ public class AirMapView
             @Override
             public void onCameraChange(CameraPosition position) {
                 LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
+                LatLng center = position.target;
                 lastBoundsEmitted = bounds;
-                eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, isTouchDown));
+                eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, center, isTouchDown));
                 view.stopMonitoringRegion();
             }
         });
@@ -412,8 +413,9 @@ public class AirMapView
 
             LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
             if (lastBoundsEmitted == null || LatLngBoundsUtils.BoundsAreDifferent(bounds, lastBoundsEmitted)) {
+                LatLng center = map.getCameraPosition().target;
                 lastBoundsEmitted = bounds;
-                eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, true));
+                eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, center, true));
             }
 
             timerHandler.postDelayed(this, 100);

--- a/android/src/main/java/com/AirMaps/RegionChangeEvent.java
+++ b/android/src/main/java/com/AirMaps/RegionChangeEvent.java
@@ -9,11 +9,13 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 public class RegionChangeEvent extends Event<RegionChangeEvent> {
     private final LatLngBounds bounds;
+    private final LatLng center;
     private boolean continuous;
 
-    public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous) {
+    public RegionChangeEvent(int id, LatLngBounds bounds, LatLng center, boolean continuous) {
         super(id, System.currentTimeMillis());
         this.bounds = bounds;
+        this.center = center;
         this.continuous = continuous;
     }
 
@@ -34,7 +36,6 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
         event.putBoolean("continuous", continuous);
 
         WritableMap region = new WritableNativeMap();
-        LatLng center = bounds.getCenter();
         region.putDouble("latitude", center.latitude);
         region.putDouble("longitude", center.longitude);
         region.putDouble("latitudeDelta", bounds.northeast.latitude - bounds.southwest.latitude);


### PR DESCRIPTION
if the user tilts the camera the center of the viewed region is far off in the
distance, which would cause any actions based on onRegionChange lat/lng values
to appear off center

this also fixes lat/lng values being too far north/south if the user is very
zoomed out due to mercator distoritions