### PR TITLE
Fix crash on iOS 7 and 8 with iOS 9+ API calls

### DIFF
--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -204,4 +204,49 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
     }
 }
 
+// Include properties of MKMapView which are only available on iOS 9+
+// and check if their selector is available before calling super method.
+
+- (void)setShowsCompass:(BOOL)showsCompass {
+    if ([MKMapView instancesRespondToSelector:@selector(setShowsCompass:)]) {
+        [super setShowsCompass:showsCompass];
+    }
+}
+
+- (BOOL)showsCompass {
+    if ([MKMapView instancesRespondToSelector:@selector(showsCompass)]) {
+        return [super showsCompass];
+    } else {
+        return NO;
+    }
+}
+
+- (void)setShowsScale:(BOOL)showsScale {
+    if ([MKMapView instancesRespondToSelector:@selector(setShowsScale:)]) {
+        [super setShowsScale:showsScale];
+    }
+}
+
+- (BOOL)showsScale {
+    if ([MKMapView instancesRespondToSelector:@selector(showsScale)]) {
+        return [super showsScale];
+    } else {
+        return NO;
+    }
+}
+
+- (void)setShowsTraffic:(BOOL)showsTraffic {
+    if ([MKMapView instancesRespondToSelector:@selector(setShowsTraffic:)]) {
+        [super setShowsTraffic:showsTraffic];
+    }
+}
+
+- (BOOL)showsTraffic {
+    if ([MKMapView instancesRespondToSelector:@selector(showsTraffic)]) {
+        return [super showsTraffic];
+    } else {
+        return NO;
+    }
+}
+
 @end


### PR DESCRIPTION
This fixes a crash when iOS 7 and 8 mapview properties `showsCompass`, `showsScale` or `showsTraffic` are defined. These properties are only available on iOS 9+.

Similar to the origin react-native MapView (RCTMap.m) this checks if the super class (MKMapView) has selectors to set and get these parameters. If not it does nothing or return false.