### PR TITLE
Add comma

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,7 @@ or do it manually as described below:
      @Override
      protected List<ReactPackage> getPackages() {
        return Arrays.<ReactPackage>asList(
-         new MainReactPackage()
+         new MainReactPackage(),
          new AirPackage() // <---- and This!
        );
      }


### PR DESCRIPTION
Elements must be separated by a comma, was not the case before resulting in a compilation error.
Reference: #138 