### PR TITLE
Remove hard-coded play-services API version in deps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,4 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile "com.google.android.gms:play-services-base:8.4.0"
-    compile 'com.google.android.gms:play-services-maps:8.4.0'
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,11 +37,13 @@ or do it manually as described below:
      project(':react-native-maps').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-maps/android')
    ```
 
-2. in `android/app/build.gradle` add:
+2. in `android/app/build.gradle` add the following lines. If your project requires a different version of the play services API, you may need to, for example, downgrade to 8.3.0.
    ```
    dependencies {
        ...
        compile project(':react-native-maps')
+       compile 'com.google.android.gms:play-services-base:8.4.0'
+       compile 'com.google.android.gms:play-services-maps:8.4.0'
    }
    ```
 


### PR DESCRIPTION
**Problem:** Cannot be used out of the box with [`react-native-gcm-android`](https://github.com/oney/react-native-gcm-android) since that required play-services `8.3.0`. Resulting name collision results in cryptic runtime errors. For comparison, [`react-native-gcm-android` installation instructions](https://github.com/oney/react-native-gcm-android#installation) include:

```
    compile 'com.google.android.gms:play-services-gcm:8.3.0' // <- Add this line
```

**Solution:** Feel free to accept or reject this PR, but the convention of moving dependencies to the app makes a certain amount of sense to me so that the repo doesn't need to be forked in order to fix the issue. This approach requires negligible extra work, has the same result, and makes the dependency explicit and somewhat easier to recognize and track down.

Thanks for the plugin!