### PR TITLE
Cocoapods spec + installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,12 @@ or do it manually as described below:
 
 ## iOS
 
+### Cocoapods
+To install using Cocoapods, simply insert the following line into your `Podfile` and run `pod install`
+
+`pod 'react-native-maps', :path => '../node_modules/react-native-maps'`
+
+### Manually
 1. Open your project in XCode, right click on `Libraries` and click `Add
    Files to "Your Project Name"` Look under `node_modules/react-native-maps/ios` and add `AIRMaps.xcodeproj`.
 2. Add `libAIRMaps.a` to `Build Phases -> Link Binary With Libraries.

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "react-native-maps"
+  s.version      = "0.3.1"
+  s.summary      = "React Native Mapview component for iOS + Android"
+
+  s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }
+  s.homepage     = "https://github.com/lelandrichardson/react-native-maps#readme"
+  s.license      = "MIT"
+  s.platform     = :ios, "8.0"
+
+  s.source       = { :git => "https://github.com/lelandrichardson/react-native-maps.git" }
+  s.source_files  = "ios/AirMaps/**/*.{h,m}"
+
+  s.dependency 'React'
+end
+


### PR DESCRIPTION
I use cocoapods for some other dependencies (not react-native related) and rnpm never plays nice with it. The podspec file is all that's needed for someone to install via cocoapods.

You don't have to publish this to cocoapods (although you can if you want), but you do have to keep the version updated within the podspec file going forward.

I hope you'll accept this to make some of our lives easier. Thanks for the awesome package!