### PR TITLE
Fix Circle overlay

### DIFF
--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -88,6 +88,7 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
         ((AIRMapPolygon *)subview).map = self;
         [self addOverlay:(id<MKOverlay>)subview];
     } else if ([subview isKindOfClass:[AIRMapCircle class]]) {
+        ((AIRMapCircle *)subview).map = self;
         [self addOverlay:(id<MKOverlay>)subview];
     }
     [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];


### PR DESCRIPTION
Fixes #54 

The Circle wasn't updating position, when center or radius props changed. There was a missing line in `AIRMap.m`.
