### PR TITLE
Remove style instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,6 @@ declaratively controlling features on the map.
 
 ### Rendering a Map with an initial region
 
-When you render a MapView, this one need to be in absolute position with the top, left, right and bottom props set.
-If not you gonna have a blank view.
-
-## Styles
-```jsx
-const styles = StyleSheet.create({
-  map: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
-});
-```
-
 ## MapView
 ```jsx
   <MapView 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,7 +119,9 @@ To install using Cocoapods, simply insert the following line into your `Podfile`
   </application>
   ```
 
-5. Ensure that you have [Google Play Services installed](http://stackoverflow.com/a/20137324/1424349)
+5. Ensure that you have Google Play Services installed.  If you're using using Geny Motion there's help [here](http://stackoverflow.com/a/20137324/1424349).
+On a physical device you need to use the Google app and search for 'Google Play Services'. There will be a link that takes you to the play store and from there you'll
+see a button to update it (do not search within the Play Store!).
 
 **Troubleshooting**
 


### PR DESCRIPTION
removed the style guide in README.md for rendering a map with initialRegion because its not required (at least as of RN 0.23), and added some more instructions on getting google play services updated