### PR TITLE
Taking snapshots of map for ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,42 @@ render() {
 }
 ```
 
+### Take Snapshot of map
+currently only for ios, android implementation WIP
+
+```jsx
+getInitialState() {
+  return {
+    coordinate: {
+      latitude: LATITUDE,
+      longitude: LONGITUDE,
+    },
+  };
+}
+
+takeSnapshot () {
+  // arguments to 'takeSnapshot' are width, height, coordinates and callback
+  this.refs.map.takeSnapshot(300, 300, this.state.coordinate, (err, snapshot) => {
+    // snapshot contains image 'uri' - full path to image and 'data' - base64 encoded image
+    this.setState({ mapSnapshot: snapshot })
+  })
+}
+
+render() {
+  return (
+    <View>
+      <MapView initialRegion={...} ref="map">
+        <MapView.Marker coordinate={this.state.coordinate} />
+      </MapView>
+      <Image source={{ uri: this.state.mapSnapshot.uri }} />
+      <TouchableOpacity onPress={this.takeSnapshot}>
+        Take Snapshot
+      </TouchableOpacity>
+    </View>
+  );
+}
+```
+
 ### Troubleshooting
 
 #### My map is blank

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -335,6 +335,12 @@ var MapView = React.createClass({
     this._runCommand('fitToElements', [animated]);
   },
 
+  takeSnapshot: function (width, height, centerPoint, callback) {
+    const region = this.props.region || this.props.initialRegion;
+    centerPoint = centerPoint || { latitude: region.latitude, longitude: region.longitude }
+    this._runCommand('takeSnapshot', [width, height, centerPoint, callback]);
+  },
+
   _getHandle: function() {
     return React.findNodeHandle(this.refs.map);
   },

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -335,10 +335,11 @@ var MapView = React.createClass({
     this._runCommand('fitToElements', [animated]);
   },
 
-  takeSnapshot: function (width, height, centerPoint, callback) {
-    const region = this.props.region || this.props.initialRegion;
-    centerPoint = centerPoint || { latitude: region.latitude, longitude: region.longitude }
-    this._runCommand('takeSnapshot', [width, height, centerPoint, callback]);
+  takeSnapshot: function (width, height, region, callback) {
+    if (!region) {
+      region = this.props.region || this.props.initialRegion;
+    }
+    this._runCommand('takeSnapshot', [width, height, region, callback]);
   },
 
   _getHandle: function() {

--- a/example/App.js
+++ b/example/App.js
@@ -17,6 +17,7 @@ var AnimatedMarkers = require('./examples/AnimatedMarkers');
 var Callouts = require('./examples/Callouts');
 var Overlays = require('./examples/Overlays');
 var DefaultMarkers = require('./examples/DefaultMarkers');
+var TakeSnapshot = require('./examples/TakeSnapshot');
 
 
 var App = React.createClass({
@@ -78,6 +79,7 @@ var App = React.createClass({
       [Callouts, 'Custom Callouts'],
       [Overlays, 'Circles, Polygons, and Polylines'],
       [DefaultMarkers, 'Default Markers'],
+      [TakeSnapshot, 'Take Snapshot'],
     ]);
   },
 });

--- a/example/examples/TakeSnapshot.js
+++ b/example/examples/TakeSnapshot.js
@@ -29,7 +29,9 @@ var MarkerTypes = React.createClass({
   takeSnapshot() {
     this.refs.map.takeSnapshot(300, 300, {
       latitude: LATITUDE - SPACE,
-      longitude: LONGITUDE - SPACE
+      longitude: LONGITUDE - SPACE,
+      latitudeDelta: 0.01,
+      longitudeDelta: 0.01 * ASPECT_RATIO
     }, (err, data) => {
       if (err) console.log(err)
       this.setState({ mapSnapshot: data })

--- a/example/examples/TakeSnapshot.js
+++ b/example/examples/TakeSnapshot.js
@@ -1,0 +1,132 @@
+var React = require('react-native');
+var {
+  StyleSheet,
+  PropTypes,
+  View,
+  Text,
+  Dimensions,
+  TouchableOpacity,
+  Image,
+} = React;
+
+var MapView = require('react-native-maps');
+var PriceMarker = require('./PriceMarker');
+
+var { width, height } = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+const SPACE = 0.01;
+
+var MarkerTypes = React.createClass({
+  getInitialState() {
+    return { mapSnapshot: null }
+  },
+
+  takeSnapshot() {
+    this.refs.map.takeSnapshot(300, 300, {
+      latitude: LATITUDE - SPACE,
+      longitude: LONGITUDE - SPACE
+    }, (err, data) => {
+      if (err) console.log(err)
+      this.setState({ mapSnapshot: data })
+    });
+  },
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          ref="map"
+          style={styles.map}
+          initialRegion={{
+            latitude: LATITUDE,
+            longitude: LONGITUDE,
+            latitudeDelta: LATITUDE_DELTA,
+            longitudeDelta: LONGITUDE_DELTA,
+          }}
+          >
+          <MapView.Marker
+            coordinate={{
+              latitude: LATITUDE + SPACE,
+              longitude: LONGITUDE + SPACE,
+            }}
+            centerOffset={{ x: -18, y: -60 }}
+            anchor={{ x: 0.69, y: 1 }}
+            image={require('./assets/flag-blue.png')}
+            />
+          <MapView.Marker
+            coordinate={{
+              latitude: LATITUDE - SPACE,
+              longitude: LONGITUDE - SPACE,
+            }}
+            centerOffset={{ x: -42, y: -60 }}
+            anchor={{ x: 0.84, y: 1 }}
+            image={require('./assets/flag-pink.png')}
+            />
+        </MapView>
+
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity onPress={this.takeSnapshot} style={[styles.bubble, styles.button]}>
+            <Text>Take snapshot</Text>
+          </TouchableOpacity>
+        </View>
+        {this.state.mapSnapshot
+          ? <TouchableOpacity
+            style={[styles.container, styles.overlay]}
+            onPress={() => this.setState({ mapSnapshot: null })}>
+              <Image
+                source={{ uri: this.state.mapSnapshot.uri }}
+                style={{ width: 300, height: 300 }}
+                />
+            </TouchableOpacity>
+            : null}
+      </View>
+    );
+  },
+});
+
+var styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  bubble: {
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 20,
+  },
+  button: {
+    width: 140,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    marginHorizontal: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    marginVertical: 20,
+    backgroundColor: 'transparent',
+  },
+  overlay: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+  }
+});
+
+module.exports = MarkerTypes;

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -147,6 +147,92 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
+        withWidth:(nonnull NSNumber *)width
+        withHeight:(nonnull NSNumber *)height
+        withCenter:(CLLocationCoordinate2D)centerPoint
+        withCallback:(RCTResponseSenderBlock)callback)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRMap class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
+        } else {
+            AIRMap *mapView = (AIRMap *)view;
+            MKMapSnapshotOptions *options = [[MKMapSnapshotOptions alloc] init];
+            MKCoordinateRegion region = mapView.region;
+
+            if (CLLocationCoordinate2DIsValid(centerPoint)) {
+                region.center.latitude = centerPoint.latitude;
+                region.center.longitude = centerPoint.longitude;
+            }
+
+            options.region = region;
+            options.size = CGSizeMake([width floatValue], [height floatValue]);
+            options.scale = [[UIScreen mainScreen] scale];
+
+            MKMapSnapshotter *snapshotter = [[MKMapSnapshotter alloc] initWithOptions:options];
+
+
+            [self takeMapSnapshot:mapView withSnapshotter:snapshotter withCallback:callback];
+
+        }
+    }];
+}
+
+#pragma mark Take Snapshot
+- (void)takeMapSnapshot:(AIRMap *)mapView
+        withSnapshotter:(MKMapSnapshotter *) snapshotter
+        withCallback:(RCTResponseSenderBlock) callback {
+    NSTimeInterval timeStamp = [[NSDate date] timeIntervalSince1970];
+    NSString *pathComponent = [NSString stringWithFormat:@"Documents/snapshot-%.20lf.png", timeStamp];
+    NSString *filePath = [NSHomeDirectory() stringByAppendingPathComponent: pathComponent];
+
+    [snapshotter startWithQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
+              completionHandler:^(MKMapSnapshot *snapshot, NSError *error) {
+                  if (error) {
+                      callback(@[error]);
+                      return;
+                  }
+                  MKAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:nil];
+
+                  UIImage *image = snapshot.image;
+                  UIGraphicsBeginImageContextWithOptions(image.size, YES, image.scale);
+                  {
+                      [image drawAtPoint:CGPointMake(0.0f, 0.0f)];
+
+                      CGRect rect = CGRectMake(0.0f, 0.0f, image.size.width, image.size.height);
+
+                      for (id <MKAnnotation> annotation in mapView.annotations) {
+                          CGPoint point = [snapshot pointForCoordinate:annotation.coordinate];
+
+                          MKAnnotationView* anView = [mapView viewForAnnotation: annotation];
+
+                          if (anView){
+                              pin = anView;
+                          }
+
+                          if (CGRectContainsPoint(rect, point)) {
+                              point.x = point.x + pin.centerOffset.x - (pin.bounds.size.width / 2.0f);
+                              point.y = point.y + pin.centerOffset.y - (pin.bounds.size.height / 2.0f);
+                              [pin.image drawAtPoint:point];
+                          }
+                      }
+
+                      UIImage *compositeImage = UIGraphicsGetImageFromCurrentImageContext();
+
+                      NSData *data = UIImagePNGRepresentation(compositeImage);
+                      [data writeToFile:filePath atomically:YES];
+                      NSDictionary *snapshotData = @{
+                                                     @"uri": filePath,
+                                                     @"data": [data base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithCarriageReturn]
+                                                     };
+                      callback(@[[NSNull null], snapshotData]);
+                  }
+                  UIGraphicsEndImageContext();
+              }];
+}
+
 #pragma mark Gesture Recognizer Handlers
 
 - (void)handleMapTap:(UITapGestureRecognizer *)recognizer {
@@ -247,7 +333,7 @@ static int kDragCenterContext;
     AIRMapMarker *marker = (AIRMapMarker *)view.annotation;
 
     BOOL isPinView = [view isKindOfClass:[MKPinAnnotationView class]];
-    
+
     id event = @{
                  @"id": marker.identifier ?: @"unknown",
                  @"coordinate": @{
@@ -255,7 +341,7 @@ static int kDragCenterContext;
                          @"longitude": @(marker.coordinate.longitude)
                          }
                  };
-    
+
     if (newState == MKAnnotationViewDragStateEnding || newState == MKAnnotationViewDragStateCanceling) {
         if (!isPinView) {
             [view setDragState:MKAnnotationViewDragStateNone animated:NO];

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -150,7 +150,7 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
 RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
         withWidth:(nonnull NSNumber *)width
         withHeight:(nonnull NSNumber *)height
-        withCenter:(CLLocationCoordinate2D)centerPoint
+        withRegion:(MKCoordinateRegion)region
         withCallback:(RCTResponseSenderBlock)callback)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
@@ -160,12 +160,6 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
         } else {
             AIRMap *mapView = (AIRMap *)view;
             MKMapSnapshotOptions *options = [[MKMapSnapshotOptions alloc] init];
-            MKCoordinateRegion region = mapView.region;
-
-            if (CLLocationCoordinate2DIsValid(centerPoint)) {
-                region.center.latitude = centerPoint.latitude;
-                region.center.longitude = centerPoint.longitude;
-            }
 
             options.region = region;
             options.size = CGSizeMake([width floatValue], [height floatValue]);


### PR DESCRIPTION
Added functionality to take snapshot of map with annotation views for ios. You can configure image size and center point. I have tested it both in simulator and real device (iPhone SE). I also work on android implementation as i need to use it in both platforms for app I am building. So I will soon send pull request with android version as well (If this one is accepted :-)). PR contains example and readme update.