### PR TITLE
Allow other versions of react-native than 0.25.1

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.25.1'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:8.4.0"
   compile 'com.google.android.gms:play-services-maps:8.4.0'
 }


### PR DESCRIPTION
Right now it seems that android is locked to 0.25.1.

I know we made the change recently after react-native-maps has been put on maven, just wondering if it is necessary to lock the version going forward or using  'com.facebook.react:react-native:+' is fine.