### PR TITLE
Marker select deselect doc update

### DIFF
--- a/components/MapMarker.js
+++ b/components/MapMarker.js
@@ -180,6 +180,8 @@ var MapMarker = React.createClass({
 
     /**
      * Callback that is called when the marker is deselected, before the callout is hidden.
+     *
+     * @platform ios
      */
     onDeselect: PropTypes.func,
 

--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -32,8 +32,8 @@
 | `onPanDrag` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user presses and drags the map. **NOTE**: for iOS `scrollEnabled` should be set to false to trigger the event
 | `onLongPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user makes a "long press" somewhere on the map.
 | `onMarkerPress` |  | Callback that is called when a marker on the map is tapped by the user.
-| `onMarkerSelect` |  | Callback that is called when a marker on the map becomes selected. This will be called when the callout for that marker is about to be shown.
-| `onMarkerDeselect` |  | Callback that is called when a marker on the map becomes deselected. This will be called when the callout for that marker is about to be hidden.
+| `onMarkerSelect` |  | Callback that is called when a marker on the map becomes selected. This will be called when the callout for that marker is about to be shown. **Note**: iOS only.
+| `onMarkerDeselect` |  | Callback that is called when a marker on the map becomes deselected. This will be called when the callout for that marker is about to be hidden. **Note**: iOS only.
 | `onCalloutPress` |  | Callback that is called when a callout is tapped by the user.
 | `onMarkerDragStart` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the user initiates a drag on a marker (if it is draggable)
 | `onMarkerDrag` | `{ coordinate: LatLng, position: Point }` | Callback called continuously as a marker is dragged

--- a/docs/marker.md
+++ b/docs/marker.md
@@ -21,8 +21,8 @@
 | Event Name | Returns | Notes
 |---|---|---|
 | `onPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the user presses on the marker
-| `onSelect` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the user selects the marker, before the callout is shown.
-| `onDeselect` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the marker is deselected, before the callout is hidden.
+| `onSelect` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the user selects the marker, before the callout is shown. **Note**: iOS only.
+| `onDeselect` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the marker is deselected, before the callout is hidden. **Note**: iOS only.
 | `onCalloutPress` |  | Callback that is called when the user taps the callout view.
 | `onDragStart` | `{ coordinate: LatLng, position: Point }` | Callback that is called when the user initiates a drag on this marker (if it is draggable)
 | `onDrag` | `{ coordinate: LatLng, position: Point }` | Callback called continuously as the marker is dragged


### PR DESCRIPTION
`onSelect` and `onDeselect` are only available for iOS at the moment.

Added `@platform ios` for `onDeselect ` in `MapMarker.js` but it was already there for `onSelect`