### PR TITLE
[MapMarker] Return id and coordinates on marker press

### DIFF
--- a/ios/AirMaps/AIRMapMarkerManager.m
+++ b/ios/AirMaps/AIRMapMarkerManager.m
@@ -102,6 +102,11 @@ RCT_EXPORT_METHOD(hideCallout:(nonnull NSNumber *)reactTag)
     // the actual marker got clicked
     id event = @{
             @"action": @"marker-press",
+            @"id": marker.identifier ?: @"unknown",
+            @"coordinate": @{
+                    @"latitude": @(marker.coordinate.latitude),
+                    @"longitude": @(marker.coordinate.longitude)
+            }
     };
 
     if (marker.onPress) marker.onPress(event);


### PR DESCRIPTION
According to the docs `onPress` should return coordinates of the maker, similiar to `onSelect`. This was working fine for Android but was missing from iOS.

/cc @jrichardlai 