### PR TITLE
0.4 stable

### DIFF
--- a/android/src/main/java/com/AirMaps/AirMapManager.java
+++ b/android/src/main/java/com/AirMaps/AirMapManager.java
@@ -1,6 +1,7 @@
 package com.AirMaps;
 
 import android.view.View;
+import android.app.Activity;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
@@ -41,18 +42,21 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
 
     private ReactContext reactContext;
 
+    private Activity reactActivity;
     private AirMapMarkerManager markerManager;
     private AirMapPolylineManager polylineManager;
     private AirMapPolygonManager polygonManager;
     private AirMapCircleManager circleManager;
 
     public AirMapManager(
+        Activity activity,
         AirMapMarkerManager markerManager,
         AirMapPolylineManager polylineManager,
         AirMapPolygonManager polygonManager,
         AirMapCircleManager circleManager
     ) {
         super();
+        this.reactActivity = activity;
         this.markerManager = markerManager;
         this.polylineManager = polylineManager;
         this.polygonManager = polygonManager;
@@ -70,7 +74,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         AirMapView view = new AirMapView(context, this);
 
         try {
-            MapsInitializer.initialize(context.getApplicationContext());
+            MapsInitializer.initialize(this.reactActivity);
         } catch (Exception e) {
             e.printStackTrace();
             emitMapError("Map initialize error", "map_init_error");

--- a/android/src/main/java/com/AirMaps/AirMapManager.java
+++ b/android/src/main/java/com/AirMaps/AirMapManager.java
@@ -71,14 +71,14 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     @Override
     protected AirMapView createViewInstance(ThemedReactContext context) {
         reactContext = context;
-        AirMapView view = new AirMapView(context, this);
 
         try {
-            MapsInitializer.initialize(this.reactActivity);
+            MapsInitializer.initialize(reactActivity);
         } catch (Exception e) {
             e.printStackTrace();
             emitMapError("Map initialize error", "map_init_error");
         }
+        AirMapView view = new AirMapView(context, reactActivity, this);
 
         return view;
     }
@@ -256,7 +256,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     }
 
     public void pushEvent(View view, String name, WritableMap data) {
-        ReactContext reactContext = (ReactContext) view.getContext();
         reactContext.getJSModule(RCTEventEmitter.class)
                 .receiveEvent(view.getId(), name, data);
     }

--- a/android/src/main/java/com/AirMaps/AirMapView.java
+++ b/android/src/main/java/com/AirMaps/AirMapView.java
@@ -1,6 +1,6 @@
 package com.AirMaps;
 
-
+import android.app.Activity;
 import android.graphics.Point;
 import android.os.Handler;
 import android.support.v4.view.GestureDetectorCompat;
@@ -60,13 +60,16 @@ public class AirMapView
     private LifecycleEventListener lifecycleListener;
     private boolean paused = false;
 
+    private ThemedReactContext context;
+    
     final EventDispatcher eventDispatcher;
 
 
 
-    public AirMapView(ThemedReactContext context, AirMapManager manager) {
-        super(context);
+    public AirMapView(ThemedReactContext context, Activity activity, AirMapManager manager) {
+        super(activity);
         this.manager = manager;
+        this.context = context;
 
         super.onCreate(null);
         super.onResume();
@@ -210,7 +213,7 @@ public class AirMapView
             }
         };
 
-        ((ThemedReactContext) getContext()).addLifecycleEventListener(lifecycleListener);
+        context.addLifecycleEventListener(lifecycleListener);
     }
 
     /*
@@ -218,7 +221,7 @@ public class AirMapView
      */
     public synchronized  void doDestroy() {
         if (lifecycleListener != null) {
-            ((ThemedReactContext) getContext()).removeLifecycleEventListener(lifecycleListener);
+            context.removeLifecycleEventListener(lifecycleListener);
             lifecycleListener = null;
         }
         if(!paused) {

--- a/android/src/main/java/com/AirMaps/AirPackage.java
+++ b/android/src/main/java/com/AirMaps/AirPackage.java
@@ -1,5 +1,7 @@
 package com.AirMaps;
 
+import android.app.Activity;
+
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -11,6 +13,12 @@ import java.util.Collections;
 import java.util.List;
 
 public class AirPackage implements ReactPackage {
+    private Activity reactActivity = null;
+
+    public AirPackage(Activity activity) {
+        reactActivity = activity;
+    }
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.emptyList();
@@ -29,6 +37,7 @@ public class AirPackage implements ReactPackage {
         AirMapPolygonManager polygonManager = new AirMapPolygonManager(reactContext);
         AirMapCircleManager circleManager = new AirMapCircleManager(reactContext);
         AirMapManager mapManager = new AirMapManager(
+            reactActivity,
             annotationManager,
             polylineManager,
             polygonManager,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,7 @@ To install using Cocoapods, simply insert the following line into your `Podfile`
      protected List<ReactPackage> getPackages() {
        return Arrays.<ReactPackage>asList(
          new MainReactPackage(),
-         new AirPackage() // <---- and This!
+         new AirPackage(this) // <---- and This!
        );
      }
    }

--- a/example/android/app/src/main/java/com/airmapsexplorer/MainActivity.java
+++ b/example/android/app/src/main/java/com/airmapsexplorer/MainActivity.java
@@ -36,7 +36,7 @@ public class MainActivity extends ReactActivity {
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
-            new AirPackage()
+            new AirPackage(this)
         );
     }
 }


### PR DESCRIPTION
Fix for#165 and #271 - Android 6.0 crashing on devices such as Xperia Z5 Compact, Z5 Bond and others. 

It passes the activity to the package, manager and view so that it can be used in place of the app context when initialising the MapView component.

The new code as also been tested on the following devices to ensure it continues to work as before:
Nexus 4 (Android 5), Nexus 5 (Android 6), Nexus 6P (Android 6)

It requires a change to an app's MainActivity.java to pass `this` when creating the AirPackage: `new AirPackage(this)` rather than `new AirPackage()` in the current version.