### PR TITLE
iOS: Fix a marker not being shown when using a custom image

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -26,7 +26,9 @@
 
 - (void)reactSetFrame:(CGRect)frame
 {
-    CGRect bounds = {CGPointZero, frame.size};
+    // Make sure we use the image size when available
+    CGSize size = self.image ? self.image.size : frame.size;
+    CGRect bounds = {CGPointZero, size};
 
     // The MapView is basically in charge of figuring out the center position of the marker view. If the view changed in
     // height though, we need to compensate in such a way that the bottom of the marker stays at the same spot on the


### PR DESCRIPTION
When using a custom image for the marker, and when the ```imageLoader``` sets the image before the ```reactSetFrame``` method is called on the marker, the size of the view is incorrectly set, resulting in an invisible marker.
This commit makes sure that, when an image is set before the ```reactSetFrame```, we transfer the size of the image to the marker.