### PR TITLE
Remove React dependency from podspec

### DIFF
--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -10,7 +10,5 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/lelandrichardson/react-native-maps.git" }
   s.source_files  = "ios/AirMaps/**/*.{h,m}"
-
-  s.dependency 'React'
 end
 


### PR DESCRIPTION
This allows for support for ReactNative versions >= 0.25.