### PR TITLE
Getting to work on iOS with 0.27

### DIFF
--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -9,6 +9,7 @@
 
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
+#import <React/RCTComponent.h>
 
 #import "RCTConvert+MapKit.h"
 #import "RCTComponent.h"

--- a/ios/AirMaps/AIRMapCallout.h
+++ b/ios/AirMaps/AIRMapCallout.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTView.h"
+#import "React/RCTView.h"
 
 
 @interface AIRMapCallout : RCTView

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -10,5 +10,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/lelandrichardson/react-native-maps.git" }
   s.source_files  = "ios/AirMaps/**/*.{h,m}"
+
+  s.dependency 'React'
 end
 


### PR DESCRIPTION
Ok, so my last PR removed the React dependency as it's latest pod source references an outdated version of `0.14`.  In order to get this completely working I am doing the following in my project's `ios/Podfile`:

```ruby
source 'https://github.com/CocoaPods/Specs.git'
platform :ios, '8.0'
use_frameworks!

workspace 'my-project.xcworkspace'
project 'my-project.xcodeproj'

target 'my-project' do
  # Depending on how your project is organized, your node_modules directory may be
  # somewhere else; tell CocoaPods where you've installed react-native from npm
  pod 'React', :path => '../node_modules/react-native'
  pod 'React/Core', path: '../node_modules/react-native'
  pod 'React/RCTGeolocation', :path => '../node_modules/react-native'
  pod 'React/RCTImage', :path => '../node_modules/react-native'
  pod 'React/RCTNetwork', :path => '../node_modules/react-native'
  pod 'React/RCTText', :path => '../node_modules/react-native'
  pod 'React/RCTWebSocket', :path => '../node_modules/react-native'
  pod 'react-native-maps'
end
```

I then add the `React.framework` to my Linked Libraries, and everything works.  I'm not sure if this is the best way to solve this, but thought I'd post this to start a discussion or help people in the interim.