### PR TITLE
Follow user location continuously, if specified

### DIFF
--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -434,7 +434,7 @@ static int kDragCenterContext;
         [mapView setRegion:region animated:YES];
 
         // Move to user location only for the first time it loads up.
-        mapView.followUserLocation = NO;
+        // mapView.followUserLocation = NO;
     }
 }
 


### PR DESCRIPTION
In my opinion this should be the developers choice, without this prop it is unnecessary hard to develop a mapkit-like behaviour for ios where the map follows the users location.

<Button 
icon={like.the.arrow.on.ios.maps}
placement={top.left.or.anywhere.really.on.the.map}
onPress={this.setState(followuser: toggle true/false} />

<Map followuser={this.state.followuser}>

For Android you'll still need a custom camera controller, but that should be the developers choice how to handle this situation. The followuser is very smooth for iOS.!