### PR TITLE
Bump Android version to 0.6.0 and use RN 0.27.2

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,7 +14,7 @@
 # org.gradle.parallel=true
 #Thu May 12 17:26:12 PDT 2016
 VERSION_CODE=2
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=React Native Map view component for Android

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:+'
+  compile 'com.facebook.react:react-native:0.27.2'
   compile "com.google.android.gms:play-services-base:8.4.0"
   compile 'com.google.android.gms:play-services-maps:8.4.0'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -100,6 +100,6 @@ android {
 
 dependencies {
     compile "com.android.support:appcompat-v7:23.4.0"
-    compile "com.facebook.react:react-native:0.25.1"  // From node_modules
+    compile "com.facebook.react:react-native:0.27.2"  // From node_modules
     compile project(':react-native-maps')
 }

--- a/example/examples/AnimatedMarkers.js
+++ b/example/examples/AnimatedMarkers.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -8,7 +9,7 @@ var {
   TouchableOpacity,
   Animated,
   Platform,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 

--- a/example/examples/AnimatedPriceMarker.js
+++ b/example/examples/AnimatedPriceMarker.js
@@ -1,10 +1,13 @@
-import React, {
+var React = require('react');
+var ReactNative = require('react-native');
+var {
   StyleSheet,
   PropTypes,
   View,
   Text,
   Animated,
-} from 'react-native';
+} = ReactNative;
+var PropTypes = require('ReactPropTypes');
 
 const PriceMarker = ({ amount, selected, style }) => {
 

--- a/example/examples/AnimatedViews.js
+++ b/example/examples/AnimatedViews.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -8,7 +9,7 @@ var {
   TouchableOpacity,
   Animated,
   Platform,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PanController = require('./PanController');

--- a/example/examples/CachedMap.js
+++ b/example/examples/CachedMap.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   Text,
   View,
@@ -6,7 +7,7 @@ var {
   StyleSheet,
   ListView,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 

--- a/example/examples/Callouts.js
+++ b/example/examples/Callouts.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -7,7 +8,7 @@ var {
   Dimensions,
   TouchableOpacity,
   Image,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/CustomCallout.js
+++ b/example/examples/CustomCallout.js
@@ -1,9 +1,10 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   View,
   Text,
-} = React;
+} = ReactNative;
 
 var CustomCallout = React.createClass({
   render() {

--- a/example/examples/DefaultMarkers.js
+++ b/example/examples/DefaultMarkers.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -6,7 +7,7 @@ var {
   Text,
   Dimensions,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 

--- a/example/examples/DisplayLatLng.js
+++ b/example/examples/DisplayLatLng.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -6,7 +7,7 @@ var {
   Text,
   Dimensions,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 

--- a/example/examples/DraggableMarkers.js
+++ b/example/examples/DraggableMarkers.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -7,7 +8,7 @@ var {
   Dimensions,
   TouchableOpacity,
   Image,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/EventListener.js
+++ b/example/examples/EventListener.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -7,7 +8,7 @@ var {
   Dimensions,
   TouchableOpacity,
   ScrollView,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/LoadingMap.js
+++ b/example/examples/LoadingMap.js
@@ -1,10 +1,11 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   Text,
   View,
   Dimensions,
   StyleSheet,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 

--- a/example/examples/MarkerTypes.js
+++ b/example/examples/MarkerTypes.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -7,7 +8,7 @@ var {
   Dimensions,
   TouchableOpacity,
   Image,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/Overlays.js
+++ b/example/examples/Overlays.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -7,7 +8,7 @@ var {
   Dimensions,
   TouchableOpacity,
   Image,
-  } = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 

--- a/example/examples/PanController.js
+++ b/example/examples/PanController.js
@@ -1,10 +1,12 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   View,
   Animated,
   PropTypes,
   PanResponder,
-  } = React;
+} = ReactNative;
+var PropTypes = require('ReactPropTypes');
 
 var ModePropType = PropTypes.oneOf(["decay", "snap", "spring-origin"]);
 var OvershootPropType = PropTypes.oneOf(["spring", "clamp"]);

--- a/example/examples/PolygonCreator.js
+++ b/example/examples/PolygonCreator.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -6,7 +7,7 @@ var {
   Text,
   Dimensions,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/PolylineCreator.js
+++ b/example/examples/PolylineCreator.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -6,7 +7,7 @@ var {
   Text,
   Dimensions,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/PriceMarker.js
+++ b/example/examples/PriceMarker.js
@@ -1,9 +1,10 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   View,
   Text,
-} = React;
+} = ReactNative;
 
 var PriceMarker = React.createClass({
   getDefaultProps() {

--- a/example/examples/TakeSnapshot.js
+++ b/example/examples/TakeSnapshot.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -7,7 +8,7 @@ var {
   Dimensions,
   TouchableOpacity,
   Image,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/ViewsAsMarkers.js
+++ b/example/examples/ViewsAsMarkers.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   StyleSheet,
   PropTypes,
@@ -6,7 +7,7 @@ var {
   Text,
   Dimensions,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 var MapView = require('react-native-maps');
 var PriceMarker = require('./PriceMarker');

--- a/example/examples/finalindexfile.js
+++ b/example/examples/finalindexfile.js
@@ -4,7 +4,8 @@
  */
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   AppRegistry,
   StyleSheet,
@@ -13,7 +14,7 @@ var {
   Dimensions,
   Animated,
   TouchableOpacity,
-  } = React;
+} = ReactNative;
 var MapView = require('react-native-maps');
 var PriceMarker = require('./components/PriceMarker');
 

--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,8 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "react": "^0.14.8",
-    "react-native": "^0.25.1",
+    "react": "15.1.0",
+    "react-native": "0.27.2",
     "react-native-maps": "../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "react-native": "latest"
+    "react": "15.1.0",
+    "react-native": "0.27.2"
   }
 }


### PR DESCRIPTION
This updates the android lib and sample to make it work with RN 0.27.2.
Unfortunately Maven Central won't let us upload the artifact with an
open dependency on RN (`+` version), so I locked it to 0.27.2 and above.
Also had to update some outdated js imports with the new ones.

Please review @lelandrichardson @christopherdro 