### PR TITLE
Pass through style even when map isn't ready

### DIFF
--- a/components/MapView.js
+++ b/components/MapView.js
@@ -437,6 +437,7 @@ var MapView = React.createClass({
       props.handlePanDrag = !!props.onPanDrag;
     } else {
       props = {
+        ...this.props,
         region: null,
         initialRegion: null,
         onChange: this._onChange,

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -437,7 +437,7 @@ var MapView = React.createClass({
       props.handlePanDrag = !!props.onPanDrag;
     } else {
       props = {
-        ...this.props,
+        style: this.props.style,
         region: null,
         initialRegion: null,
         onChange: this._onChange,


### PR DESCRIPTION
We encountered an issue at a hackathon where props (and therefore styles) was not being passed through: this means that if the map isn't ready (`this.state.isReady` is false), it is invisible unless it was given a width and height by its parent. This is an issue because on genymotion, where maps aren't available, isReady never becomes true and we can never see the error message.