### PR TITLE
fixed a bug where map completely failed to render in some situations

### DIFF
--- a/components/MapView.js
+++ b/components/MapView.js
@@ -437,6 +437,7 @@ var MapView = React.createClass({
       props.handlePanDrag = !!props.onPanDrag;
     } else {
       props = {
+        ...this.props,
         region: null,
         initialRegion: null,
         onChange: this._onChange,


### PR DESCRIPTION
Hello there, and thankyou for this wonderful module !

I'm pretty new to React-Native, and was at a hackathon yesterday at Facebook Tel Aviv.  There was a problem where the map component failed to render in some situations.  Some guys from Facebook London were there and they found this fix.  Maybe you'll accept it;  it's just one line in the `else` block of MapView's `render`, adding `...this.props` to pass through.

Cheers!