### PR TITLE
[AirMapMarker][android] fix custom marker combined with MapMarker ima…

### DIFF
--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
@@ -55,6 +55,7 @@ public class AirMapMarker extends AirMapFeature {
 
     private float markerHue = 0.0f; // should be between 0 and 360
     private BitmapDescriptor iconBitmapDescriptor;
+    private Bitmap iconBitmap;
 
     private float rotation = 0.0f;
     private boolean flat = false;
@@ -85,6 +86,7 @@ public class AirMapMarker extends AirMapFeature {
                                 Bitmap bitmap = closeableStaticBitmap.getUnderlyingBitmap();
                                 if (bitmap != null) {
                                     bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true);
+                                    iconBitmap = bitmap;
                                     iconBitmapDescriptor = BitmapDescriptorFactory.fromBitmap(bitmap);
                                 }
                             }
@@ -246,7 +248,18 @@ public class AirMapMarker extends AirMapFeature {
     private BitmapDescriptor getIcon() {
         if (hasCustomMarkerView) {
             // creating a bitmap from an arbitrary view
-            return BitmapDescriptorFactory.fromBitmap(createDrawable());
+            if (iconBitmapDescriptor != null) {
+                Bitmap viewBitmap = createDrawable();
+                int width = Math.max(iconBitmap.getWidth(), viewBitmap.getWidth());
+                int height = Math.max(iconBitmap.getHeight(), viewBitmap.getHeight());
+                Bitmap combinedBitmap = Bitmap.createBitmap(width, height, iconBitmap.getConfig());
+                Canvas canvas = new Canvas(combinedBitmap);
+                canvas.drawBitmap(iconBitmap, 0, 0, null);
+                canvas.drawBitmap(viewBitmap, 0, 0, null);
+                return BitmapDescriptorFactory.fromBitmap(combinedBitmap);
+            } else {
+                return BitmapDescriptorFactory.fromBitmap(createDrawable());
+            }
         } else if (iconBitmapDescriptor != null) {
             // use local image as a marker
             return iconBitmapDescriptor;

--- a/example/examples/MarkerTypes.js
+++ b/example/examples/MarkerTypes.js
@@ -44,7 +44,9 @@ var MarkerTypes = React.createClass({
             centerOffset={{ x: -18, y: -60 }}
             anchor={{ x: 0.69, y: 1 }}
             image={require('./assets/flag-blue.png')}
-            />
+          >
+            <Text style={styles.marker}>X</Text>
+          </MapView.Marker>
           <MapView.Marker
             coordinate={{
               latitude: LATITUDE - SPACE,
@@ -77,6 +79,11 @@ var styles = StyleSheet.create({
     right: 0,
     bottom: 0,
   },
+  marker: {
+    marginLeft: 33,
+    marginTop: 18,
+    fontWeight: 'bold',
+  }
 });
 
 module.exports = MarkerTypes;


### PR DESCRIPTION
…ge prop

previously, if you had a custom marker, the `MapMarker`'s `image` prop was ignored on android. 

![image](https://cloud.githubusercontent.com/assets/2136203/16350489/c67772e2-3a13-11e6-91d1-dd3ddf059239.png)
