### PR TITLE
Fixes `Undefined symbols for architecture x86_64: “std::terminate()”`…

### DIFF
--- a/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
+++ b/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
@@ -651,7 +651,10 @@
 				);
 				INFOPLIST_FILE = AirMapsExplorer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AirMapsExplorer;
 			};
@@ -668,7 +671,10 @@
 				);
 				INFOPLIST_FILE = AirMapsExplorer/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AirMapsExplorer;
 			};


### PR DESCRIPTION
… issue.

Seen here: [https://github.com/facebook/react-native/issues/7532](https://github.com/facebook/react-native/issues/7532)