### PR TITLE
Fix warning for iOS "loadImageWithTag is deprecated" for RN 0.28.0

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -209,9 +209,10 @@
         _reloadImageCancellationBlock();
         _reloadImageCancellationBlock = nil;
     }
-    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithTag:_imageSrc
+    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithTag:[RCTConvert NSURLRequest:_imageSrc]
                                                                      size:self.bounds.size
                                                                     scale:RCTScreenScale()
+                                                                    clipped:YES
                                                                resizeMode:UIViewContentModeCenter
                                                             progressBlock:nil
                                                           completionBlock:^(NSError *error, UIImage *image) {


### PR DESCRIPTION
There is a warning after upgrading React Native to 0.28.0 about `loadImageWithTag` being deprecated. I saw it when loading a custom image for a marker. I updated the function to what I think is the new way of loading these images. 

I'm not sure if `clipped` should be `YES` by default but I think that's the case now.

Hope this helps :)