### PR TITLE
[android] installation instructions to actually use node_modules

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,17 +13,3 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Thu May 12 17:26:12 PDT 2016
-VERSION_CODE=2
-VERSION_NAME=0.6.0
-GROUP=com.airbnb.android
-
-POM_DESCRIPTION=React Native Map view component for Android
-POM_URL=https://github.com/lelandrichardson/react-native-maps/tree/new-scv
-POM_SCM_URL=https://github.com/lelandrichardson/react-native-maps/tree/new-scv
-POM_SCM_CONNECTION=scm:git@github.com:lelandrichardson/react-native-maps.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:lelandrichardson/react-native-maps.git
-POM_LICENSE_NAME=MIT
-POM_LICENSE_URL=https://github.com/lelandrichardson/react-native-maps/blob/master/LICENSE
-POM_LICENSE_DIST=repo
-POM_DEVELOPER_ID=lelandrichardson
-POM_DEVELOPER_NAME=Leland Richardson

--- a/android/lib/gradle.properties
+++ b/android/lib/gradle.properties
@@ -1,3 +1,18 @@
+VERSION_CODE=2
+VERSION_NAME=0.6.0
+GROUP=com.airbnb.android
+
+POM_DESCRIPTION=React Native Map view component for Android
+POM_URL=https://github.com/lelandrichardson/react-native-maps/tree/new-scv
+POM_SCM_URL=https://github.com/lelandrichardson/react-native-maps/tree/new-scv
+POM_SCM_CONNECTION=scm:git@github.com:lelandrichardson/react-native-maps.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:lelandrichardson/react-native-maps.git
+POM_LICENSE_NAME=MIT
+POM_LICENSE_URL=https://github.com/lelandrichardson/react-native-maps/blob/master/LICENSE
+POM_LICENSE_DIST=repo
+POM_DEVELOPER_ID=lelandrichardson
+POM_DEVELOPER_NAME=Leland Richardson
+
 POM_NAME=ReactNative Maps library
 POM_ARTIFACT_ID=react-native-maps
 POM_PACKAGING=aar

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,18 +43,18 @@ To install using Cocoapods, simply insert the following line into your `Podfile`
 1. in `android/app/build.gradle` add:
    ```
    ...
-     dependencies {
+   dependencies {
      ...
-    compile 'com.airbnb.android:react-native-maps:0.6.0' // <-- Add this!
-    }
+     compile project(':react-native-maps') // <-- Add this!
+   }
    ```
 
 2. in `android/settings.gradle` add:
-```
-include ':react-native-maps'
-project(':react-native-maps').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-maps/android')
+   ```
+   include ':react-native-maps'
+   project(':react-native-maps').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-maps/android/lib')
 
-```
+   ```
 
 
 3. in `android/app/src/main/java/com/{YOUR_APP_NAME}/MainActivity.java` add:

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -17,16 +17,3 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_CODE=1
-VERSION_NAME=0.4.1
-GROUP=com.airbnb.android
-POM_DESCRIPTION=React Native Map view component for Android - Example app
-POM_URL=https://github.com/lelandrichardson/react-native-maps/tree/new-scv
-POM_SCM_URL=https://github.com/lelandrichardson/react-native-maps/tree/new-scv
-POM_SCM_CONNECTION=scm:git@github.com:lelandrichardson/react-native-maps.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:lelandrichardson/react-native-maps.git
-POM_LICENSE_NAME=MIT
-POM_LICENSE_URL=https://github.com/lelandrichardson/react-native-maps/blob/master/LICENSE
-POM_LICENSE_DIST=repo
-POM_DEVELOPER_ID=lelandrichardson
-POM_DEVELOPER_NAME=Leland Richardson


### PR DESCRIPTION
* And basic gradle.properties reorg to allow that

Previous `installation.md` was configuring android projects to pull their `react-native-maps` artifact from maven, and not `node_modules`. It was also uselessly [adding a settings.gradle](https://github.com/lelandrichardson/react-native-maps/blob/master/docs/installation.md#android) project for `:react-native-maps` which was never used.

This change fixes those instructions, and related project structure, to allow us to build android projects with `react-native-maps` coming from `node_modules`, just as ios projects are built.

I'm not informed about our reasoning for publishing to maven at all, but I don't believe this PR breaks that functionality.