### PR TITLE
[FIXBUG] Not calling setLoadingIndicatorColor when null

### DIFF
--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -610,7 +610,9 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             this.mapLoadingProgressBar = new ProgressBar(getContext());
             this.mapLoadingProgressBar.setIndeterminate(true);
         }
-        this.setLoadingIndicatorColor(this.loadingIndicatorColor);
+        if (this.loadingIndicatorColor != null) {
+            this.setLoadingIndicatorColor(this.loadingIndicatorColor);
+        }
         return this.mapLoadingProgressBar;
     }
 


### PR DESCRIPTION
For some reason this was not triggered before but sometimes `this.loadingIndicatorColor` is null then calling `this.setLoadingIndicatorColor` will trigger a null pointer exception