### PR TITLE
Fix shouldUsePinView

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -198,7 +198,7 @@
 
 - (BOOL)shouldUsePinView
 {
-    return self.subviews.count == 0 && !self.imageSrc;
+    return self.reactSubviews.count == 0 && !self.imageSrc;
 }
 
 - (void)setImageSrc:(NSString *)imageSrc


### PR DESCRIPTION
Update shouldUsePinView to handle when `subviews` are not yet updated to reflect `reactSubviews`.

Feel free to abandon this but quick attempt at a fix of an issue where markers were using the default pins instead of the custom react subviews. Stepping through the code it looks like this runs before [`UIView.didUpdateReactSubviews`](https://github.com/facebook/react-native/blob/master/React/Views/UIView+React.m#L132) when `subviews` are actually updated.