### PR TITLE
Revert "Fix warning for iOS "loadImageWithTag is deprecated" for RN 0.28.0

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -209,10 +209,9 @@
         _reloadImageCancellationBlock();
         _reloadImageCancellationBlock = nil;
     }
-    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithTag:[RCTConvert NSURLRequest:_imageSrc]
+    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithTag:_imageSrc
                                                                      size:self.bounds.size
                                                                     scale:RCTScreenScale()
-                                                                    clipped:YES
                                                                resizeMode:UIViewContentModeCenter
                                                             progressBlock:nil
                                                           completionBlock:^(NSError *error, UIImage *image) {


### PR DESCRIPTION
Reverting this for now as it breaks build https://github.com/lelandrichardson/react-native-maps/pull/333