### PR TITLE
RN0.29 compatability

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply from: 'gradle-maven-push.gradle'
 
 android {
   compileSdkVersion 23
@@ -16,7 +15,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.27.2'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:8.4.0"
   compile 'com.google.android.gms:play-services-maps:8.4.0'
 }

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -1,7 +1,7 @@
 package com.airbnb.android.react.maps;
 
 import android.view.View;
-import android.app.Activity;
+import android.content.Context;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
@@ -41,19 +41,19 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
 
     private ReactContext reactContext;
 
-    private Activity reactActivity;
+    private Context appContext;
     private AirMapMarkerManager markerManager;
     private AirMapPolylineManager polylineManager;
     private AirMapPolygonManager polygonManager;
     private AirMapCircleManager circleManager;
 
     public AirMapManager(
-            Activity activity,
+            Context context,
             AirMapMarkerManager markerManager,
             AirMapPolylineManager polylineManager,
             AirMapPolygonManager polygonManager,
             AirMapCircleManager circleManager) {
-        this.reactActivity = activity;
+        this.appContext = context;
         this.markerManager = markerManager;
         this.polylineManager = polylineManager;
         this.polygonManager = polygonManager;
@@ -70,12 +70,12 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         reactContext = context;
 
         try {
-            MapsInitializer.initialize(reactActivity);
+            MapsInitializer.initialize(this.appContext);
         } catch (Exception e) {
             e.printStackTrace();
             emitMapError("Map initialize error", "map_init_error");
         }
-        AirMapView view = new AirMapView(context, reactActivity, this);
+        AirMapView view = new AirMapView(context, this.appContext, this);
 
         return view;
     }

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -1,6 +1,5 @@
 package com.airbnb.android.react.maps;
 
-import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
@@ -16,6 +15,7 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 import android.view.View.OnLayoutChangeListener;
+import android.content.Context;
 
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -88,8 +88,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     final EventDispatcher eventDispatcher;
 
-    public AirMapView(ThemedReactContext context, Activity activity, AirMapManager manager) {
-        super(activity);
+    public AirMapView(ThemedReactContext context, Context appContext, AirMapManager manager) {
+        super(appContext);
         this.manager = manager;
         this.context = context;
 

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -13,11 +13,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class MapsPackage implements ReactPackage {
-    private Activity reactActivity = null;
-
-    public MapsPackage(Activity activity) {
-        reactActivity = activity;
-    }
+    public MapsPackage(Activity activity) { } // backwards compatability
+    public MapsPackage() { }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
@@ -37,7 +34,7 @@ public class MapsPackage implements ReactPackage {
         AirMapPolygonManager polygonManager = new AirMapPolygonManager(reactContext);
         AirMapCircleManager circleManager = new AirMapCircleManager(reactContext);
         AirMapManager mapManager = new AirMapManager(
-                reactActivity,
+                reactContext.getBaseContext(),
                 annotationManager,
                 polylineManager,
                 polygonManager,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ To install using Cocoapods, simply insert the following line into your `Podfile`
         protected List<ReactPackage> getPackages() {
             return Arrays.<ReactPackage>asList(
                 new MainReactPackage(),
-                new MapsPackage(this)    // <-- Add this!
+                new MapsPackage()    // <-- Add this!
             );
         }
    }
@@ -88,7 +88,7 @@ To install using Cocoapods, simply insert the following line into your `Podfile`
                .setBundleAssetName("index.android.bundle")
                .setJSMainModuleName("index.android")
                .addPackage(new MainReactPackage())
-               .addPackage(new MapsPackage(this)) // <---- and This!
+               .addPackage(new MapsPackage()) // <---- and This!
                .setUseDeveloperSupport(BuildConfig.DEBUG)
                .setInitialLifecycleState(LifecycleState.RESUMED)
                .build();


### PR DESCRIPTION
React native 0.29 has some changes to the way they initialize libraries, which means they are initialized from the `Application` rather than the `MainActivity`. We added the Activity as a constructor argument to `MapsPackage` in [PR#276](https://github.com/lelandrichardson/react-native-maps/pull/276) to fix Sony Xperia devices with Android 6.0 crashing #271.

After some experimentation and testing we've found that if you supply `ReactContext.getBaseContext()` to the Google Maps API you can get away with not needing the MainActivity. I have also left the `public MapsPackage(Activity activity) { }` constructor for backwards compatibility, but if you'd rather this was removed, let me know and I'll update the PR.

I've also updated the `build.gradle` file as per #359 to get the lib building with RN0.29.

Tested with:
Nexus 6P
Nexus 5
Sony Xperia z5 compact