### PR TITLE
Fix setup of example app for Android

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -100,6 +100,6 @@ android {
 
 dependencies {
     compile "com.android.support:appcompat-v7:23.4.0"
-    compile "com.facebook.react:react-native:0.29.0"  // From node_modules
+    compile "com.facebook.react:react-native:+"  // From node_modules
     compile project(':react-native-maps')
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -18,7 +18,7 @@ allprojects {
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$projectDir/../../node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
 }


### PR DESCRIPTION
Fix maven repo location and just use whatever version of react-native is under `node_modules`.

This matches what react-native itself does, eg:

https://github.com/facebook/react-native/blob/9b184cc0f43194f8db73d2fea0b23b1284c487f9/local-cli/generator-android/templates/src/app/build.gradle#L131