### PR TITLE
Take prop to hide the "my location" button in Android

### DIFF
--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -97,6 +97,11 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         view.setShowsUserLocation(showUserLocation);
     }
 
+    @ReactProp(name = "showsMyLocationButton", defaultBoolean = true)
+    public void setShowsMyLocationButton(AirMapView view, boolean showMyLocationButton) {
+        view.setShowsMyLocationButton(showMyLocationButton);
+    }
+
     @ReactProp(name = "toolbarEnabled", defaultBoolean = true)
     public void setToolbarEnabled(AirMapView view, boolean toolbarEnabled) {
         view.setToolbarEnabled(toolbarEnabled);

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -321,6 +321,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         }
     }
 
+    public void setShowsMyLocationButton(boolean showMyLocationButton) {
+        if (hasPermissions()) {
+            map.getUiSettings().setMyLocationButtonEnabled(showMyLocationButton);
+        }
+    }
+
     public void setToolbarEnabled(boolean toolbarEnabled) {
         if (hasPermissions()) {
             map.getUiSettings().setMapToolbarEnabled(toolbarEnabled);

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -52,6 +52,14 @@ var MapView = React.createClass({
     showsUserLocation: PropTypes.bool,
 
     /**
+     * If `false` hide the button to move map to the current user's location.
+     * Default value is `true`.
+     *
+     * @platform android
+     */
+    showsMyLocationButton: PropTypes.bool,
+
+    /**
      * If `true` the map will focus on the user's location. This only works if
      * `showsUserLocation` is true and the user has shared their location.
      * Default value is `false`.


### PR DESCRIPTION
This button is enabled by default when showsUserLocation is true; it's the gray button that shows on the top right and centers on the user location on press.

This is useful if you want to implement a different version of that in React Native, for instance.