### PR TITLE
Update AirMapMarker to use loadImageWithURLRequest

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -209,20 +209,22 @@
         _reloadImageCancellationBlock();
         _reloadImageCancellationBlock = nil;
     }
-    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithTag:_imageSrc
-                                                                     size:self.bounds.size
-                                                                    scale:RCTScreenScale()
-                                                               resizeMode:UIViewContentModeCenter
-                                                            progressBlock:nil
-                                                          completionBlock:^(NSError *error, UIImage *image) {
-                                                              if (error) {
-                                                                  // TODO(lmr): do something with the error?
-                                                                  NSLog(@"%@", error);
-                                                              }
-                                                              dispatch_async(dispatch_get_main_queue(), ^{
-                                                                self.image = image;
-                                                              });
-                                                          }];
+    NSURL *imageURLRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:imageSrc]];
+    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:imageURLRequest
+                                                                            size:self.bounds.size
+                                                                           scale:RCTScreenScale()
+                                                                         clipped:YES
+                                                                      resizeMode:UIViewContentModeCenter
+                                                                   progressBlock:nil
+                                                                 completionBlock:^(NSError *error, UIImage *image) {
+                                                                     if (error) {
+                                                                         // TODO(lmr): do something with the error?
+                                                                         NSLog(@"%@", error);
+                                                                     }
+                                                                     dispatch_async(dispatch_get_main_queue(), ^{
+                                                                       self.image = image;
+                                                                     });
+                                                                 }];
 }
 
 - (void)setPinColor:(UIColor *)pinColor


### PR DESCRIPTION
[`loadImageWithTag`](https://github.com/facebook/react-native/blob/ba4c34c0db004cda9fb561b3bdf5224d518ab32d/Libraries/Image/RCTImageLoader.m#L755) is deprecated and shows warnings on RN 0.29.

### Test Plan

On iOS, render a map with a marker that has image prop set. See marker is rendered correctly and no deprecation warnings.

```
<MapView ...>
  <MapView.Marker ... image={require('./pin.png')} />
</MapView>
```