### PR TITLE
Lower dependency on GMS packages

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -17,6 +17,6 @@ android {
 
 dependencies {
   compile 'com.facebook.react:react-native:0.29.0'
-  compile "com.google.android.gms:play-services-base:8.4.0"
-  compile 'com.google.android.gms:play-services-maps:8.4.0'
+  compile "com.google.android.gms:play-services-base:7.8.0"
+  compile 'com.google.android.gms:play-services-maps:7.8.0'
 }


### PR DESCRIPTION
I can't seem to run 8.4 on older devices (trying a galaxy s3 mini).

7.8 works fine on that device and seems to cover the functionality we need, though I didn't verify every single feature here.