### PR TITLE
Play nice with 0.29.2 on both platforms again.

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.29.0'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:8.4.0"
   compile 'com.google.android.gms:play-services-maps:8.4.0'
 }

--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -9,7 +9,6 @@
 
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
-#import <React/RCTComponent.h>
 
 #import "RCTConvert+MapKit.h"
 #import "RCTComponent.h"

--- a/ios/AirMaps/AIRMapCallout.h
+++ b/ios/AirMaps/AIRMapCallout.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "React/RCTView.h"
+#import "RCTView.h"
 
 
 @interface AIRMapCallout : RCTView

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
   "devDependencies": {
     "react": "15.2.0",
     "react-native": "0.29.0"
+  },
+  "rnpm": {
+    "android": {
+      "sourceDir": "./android/lib"
+    }
   }
 }


### PR DESCRIPTION
Just a few changes to make things work out of the box again.

Android:

* Changing the build gradle to use the "current" version instead of a specific version.  I read in another issue that wasn't the preferred way and that React Native gets it wrong?   I'm not sure how to solve this correctly, this works though.  I like what's written on the README:  we link to the latest version (using *)... this change sort of sees that through.

* Provides a hint to `rnpm` (aka `react-native link`) in package.json to hookup settings to the `lib` folder directly.  Not quite sure why I had to do this.  Perhaps it's a standard to live in the `android` folder?  It seems like we have two ways of linking... via source and via maven?  

iOS:

* Fixes two header files which suddenly stops working in the latest React Native.



