### PR TITLE
Supports React Native 0.30 on both platforms again

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -17,6 +17,6 @@ android {
 
 dependencies {
   compile 'com.facebook.react:react-native:+'
-  compile "com.google.android.gms:play-services-base:9.2.0"
-  compile 'com.google.android.gms:play-services-maps:9.2.0'
+  compile "com.google.android.gms:play-services-base:8.4.0"
+  compile 'com.google.android.gms:play-services-maps:8.4.0'
 }

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.29.2'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:9.2.0"
   compile 'com.google.android.gms:play-services-maps:9.2.0'
 }

--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -9,7 +9,6 @@
 
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
-#import <React/RCTComponent.h>
 
 #import "RCTConvert+MapKit.h"
 #import "RCTComponent.h"

--- a/ios/AirMaps/AIRMapCallout.h
+++ b/ios/AirMaps/AIRMapCallout.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "React/RCTView.h"
+#import "RCTView.h"
 
 
 @interface AIRMapCallout : RCTView

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "google-maps",
     "mapkit"
   ],
-  "dependencies": {
-    "react": "15.2.0",
-    "react-native": "^0.29.2"
+  "peerDependencies": {
+    "react": ">=15.2.0",
+    "react-native": ">=0.30.0"
   },
   "devDependencies": {
     "react": "15.2.0",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
   "devDependencies": {
     "react": "15.2.0",
     "react-native": "^0.29.2"
+  },
+  "rnpm": {
+    "android": {
+      "sourceDir": "./android/lib"
+    }
   }
 }


### PR DESCRIPTION
Here's a few things that will make `react-native-maps` work again now that React Native 0.30 is here.

Before you read to code, i just want ensure I'm not trolling you here. I adore `react-native-maps` and just want it to work out of the box and survive upgrades of React Native.

### Android

* Set the dependency to for React Native to `+`.    I know y'all have issues with this, but I believe this is straight forward and works.  <3
* Downgrade play services back to 8.4.0 as this will cause android clients to need to upgrade to work.  Just a compatibility thing.

### iOS

* Two small header imports were broken.

### Package.json

* Set the `rnpm` hint in `package.json` to point it to the right code so it gets linked properly.
* Changed the dependency to peerDependency.  Just relies on the host to install the right version.  This change is similar in spirit to the old `*` you just replaced.

### How To Test

`npm i --save skellock/react-native-maps#friends-with-30` on a fresh `react-native init` project if you'd like to test in advance.

Just to reinterate.  These changes are just to play well with RN upgrades and make this awesome project work out of the box again.

### Thanks!

Cheers and thanks for all your hard work on this project.