### PR TITLE
Include import line in Java application

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,6 +54,8 @@ For React Native v0.29.0 or above:
 2. in your application object, add:
 
 ```java
+import com.airbnb.android.react.maps.MapsPackage;
+
 public class MyApplication extends Application implements ReactApplication {
   private final ReactNativeHost reactNativeHost = new ReactNativeHost(this) {
     @Override protected List<ReactPackage> getPackages() {


### PR DESCRIPTION
Adding `MapsPackage` to the list doesn't work if the import statement hasn't been added to the file.