### PR TITLE
Use Activity to initialize Google Map

### DIFF
--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -1,0 +1,22 @@
+package com.airbnb.android.react.maps;
+
+import android.app.Activity;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+
+public class AirMapModule extends ReactContextBaseJavaModule {
+
+    public AirMapModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "AirMapModule";
+    }
+
+    public Activity getActivity() {
+        return getCurrentActivity();
+    }
+}

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -4,6 +4,7 @@ import android.view.View;
 import android.content.Context;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -41,9 +42,9 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
 
     private ReactContext reactContext;
 
-    private final Context appContext;
+    private final ReactApplicationContext appContext;
 
-    public AirMapManager(Context context) {
+    public AirMapManager(ReactApplicationContext context) {
         this.appContext = context;
     }
 
@@ -57,7 +58,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         reactContext = context;
 
         try {
-            MapsInitializer.initialize(this.appContext);
+            MapsInitializer.initialize(new AirMapModule(this.appContext).getActivity());
         } catch (RuntimeException e) {
             e.printStackTrace();
             emitMapError("Map initialize error", "map_init_error");

--- a/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -33,7 +33,7 @@ public class MapsPackage implements ReactPackage {
         AirMapPolylineManager polylineManager = new AirMapPolylineManager(reactContext);
         AirMapPolygonManager polygonManager = new AirMapPolygonManager(reactContext);
         AirMapCircleManager circleManager = new AirMapCircleManager(reactContext);
-        AirMapManager mapManager = new AirMapManager(reactContext.getBaseContext());
+        AirMapManager mapManager = new AirMapManager(reactContext);
 
         return Arrays.<ViewManager>asList(
                 calloutManager,


### PR DESCRIPTION
Update AirMapManager to use Activity obtained from ReactContextBaseJavaModule (part of update from [RN v0.29.0](https://github.com/facebook/react-native/releases/tag/v0.29.0))

This might address issues like #165 

Note: Not tested for backward compatibility