### PR TITLE
Clarify which build.gradle to modify in Installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ To install using Cocoapods, simply insert the following line into your `Podfile`
 
 ## Android
 
-1. in your `build.gradle` add:
+1. in your `android/app/build.gradle` add:
 ```groovy
 ...
 dependencies {


### PR DESCRIPTION
Users may mistakenly modify android/build.gradle instead of android/app/build.gradle. This PR clarifies which file to modify.