### PR TITLE
[CRASH] Added check on marker class in predicate

### DIFF
--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -176,7 +176,7 @@ RCT_EXPORT_METHOD(fitToSuppliedMarkers:(nonnull NSNumber *)reactTag
 
             NSPredicate *filterMarkers = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
                 AIRMapMarker *marker = (AIRMapMarker *)evaluatedObject;
-                return [markers containsObject:marker.identifier];
+                return [marker isKindOfClass:[AIRMapMarker class]] && [markers containsObject:marker.identifier];
             }];
 
             NSArray *filteredMarkers = [mapView.annotations filteredArrayUsingPredicate:filterMarkers];


### PR DESCRIPTION
The current implementation will crash if you call fitToSuppliedMarkers while showsUserLocation is set to true because of an unchecked cast of the MKUserLocation marker.