### PR TITLE
Remove unused `NativeMethodsMixin` for compat with RN 0.32

### DIFF
--- a/components/MapCallout.js
+++ b/components/MapCallout.js
@@ -1,15 +1,12 @@
 import React, { PropTypes } from 'react';
 import {
   View,
-  NativeMethodsMixin,
   requireNativeComponent,
   StyleSheet,
 } from 'react-native';
 
 // eslint-disable-next-line react/prefer-es6-class
 const MapCallout = React.createClass({
-  mixins: [NativeMethodsMixin],
-
   propTypes: {
     ...View.propTypes,
     tooltip: PropTypes.bool,

--- a/components/MapCircle.js
+++ b/components/MapCircle.js
@@ -1,14 +1,11 @@
 import React, { PropTypes } from 'react';
 import {
   View,
-  NativeMethodsMixin,
   requireNativeComponent,
 } from 'react-native';
 
 // eslint-disable-next-line react/prefer-es6-class
 const MapCircle = React.createClass({
-  mixins: [NativeMethodsMixin],
-
   propTypes: {
     ...View.propTypes,
 

--- a/components/MapMarker.js
+++ b/components/MapMarker.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import {
   View,
-  NativeMethodsMixin,
   requireNativeComponent,
   StyleSheet,
   Platform,
@@ -14,8 +13,6 @@ const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSou
 
 // eslint-disable-next-line react/prefer-es6-class
 const MapMarker = React.createClass({
-  mixins: [NativeMethodsMixin],
-
   viewConfig: {
     uiViewClassName: 'AIRMapMarker',
     validAttributes: {

--- a/components/MapPolygon.js
+++ b/components/MapPolygon.js
@@ -1,14 +1,11 @@
 import React, { PropTypes } from 'react';
 import {
   View,
-  NativeMethodsMixin,
   requireNativeComponent,
 } from 'react-native';
 
 // eslint-disable-next-line react/prefer-es6-class
 const MapPolygon = React.createClass({
-  mixins: [NativeMethodsMixin],
-
   propTypes: {
     ...View.propTypes,
 

--- a/components/MapPolyline.js
+++ b/components/MapPolyline.js
@@ -1,14 +1,11 @@
 import React, { PropTypes } from 'react';
 import {
   View,
-  NativeMethodsMixin,
   requireNativeComponent,
 } from 'react-native';
 
 // eslint-disable-next-line react/prefer-es6-class
 const MapPolyline = React.createClass({
-  mixins: [NativeMethodsMixin],
-
   propTypes: {
     ...View.propTypes,
 

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import {
   EdgeInsetsPropType,
-  NativeMethodsMixin,
   Platform,
   View,
   Animated,
@@ -18,8 +17,6 @@ import MapCallout from './MapCallout';
 
 // eslint-disable-next-line react/prefer-es6-class
 const MapView = React.createClass({
-  mixins: [NativeMethodsMixin],
-
   viewConfig: {
     uiViewClassName: 'AIRMap',
     validAttributes: {


### PR DESCRIPTION
Remove the unused `NativeMethodsMixin`, which is undefined in
`react-native` 0.32.0, causing yellowbox warnings.

Related: #490

cc: @lelandrichardson 