### PR TITLE
Make ScrollView in example/App.js full-width

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -61,6 +61,7 @@ const App = React.createClass({
         {Component && this.renderBackButton()}
         {!Component && (
           <ScrollView
+            style={StyleSheet.absoluteFill}
             contentContainerStyle={styles.scrollview}
             showsVerticalScrollIndicator={false}
           >


### PR DESCRIPTION
The example app had bad UX because you could only scroll in the middle
of the screen. Make the `<ScrollView />` use `StyleSheet.absoluteFill`
to make it full-width.

### Before
![before](http://g.recordit.co/kwmyYTZnol.gif)

### After
![after](http://g.recordit.co/Qgv3Q3tdvy.gif)