### PR TITLE
Bumped google-play-things in build.gradle to 9.+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ android {
 
 dependencies {
   compile 'com.facebook.react:react-native:0.32.0'
-  compile "com.google.android.gms:play-services-base:8.4.0"
-  compile 'com.google.android.gms:play-services-maps:8.4.0'
+  compile "com.google.android.gms:play-services-base:9.+"
+  compile 'com.google.android.gms:play-services-maps:9.+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ android {
 
 dependencies {
   compile 'com.facebook.react:react-native:0.32.0'
-  compile "com.google.android.gms:play-services-base:9.+"
-  compile 'com.google.android.gms:play-services-maps:9.+'
+  compile "com.google.android.gms:play-services-base:9.4.0"
+  compile 'com.google.android.gms:play-services-maps:9.4.0'
 }


### PR DESCRIPTION
Bumping build.gradle to use latest version of google-play, should fix crashing when conflicting with other node modules that use the 9.+ version