### PR TITLE
Fix a few spots where forgot to update version from 0.7.1 to 0.8.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 VERSION_CODE=2
-VERSION_NAME=0.7.1
+VERSION_NAME=0.8.0
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=React Native Map view component for Android

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-maps"
-  s.version      = "0.7.1"
+  s.version      = "0.8.0"
   s.summary      = "React Native Mapview component for iOS + Android"
 
   s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }


### PR DESCRIPTION
Update the respective Android & iOS versioning files to indicate we're
on version 0.8.0 instead of 0.7.1.

Does this warrant publishing 0.8.1 (with the proper files updated 😜) so that people can consume the correct versions with Cocoapods/Gradle?

to: @christopherdro @lelandrichardson 