### PR TITLE
Use latest version of RN to build Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.32.0'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:9.4.0"
   compile 'com.google.android.gms:play-services-maps:9.4.0'
 }


### PR DESCRIPTION
Currently it's not possible to build an Android app when using RN 0.32.1 because it's looking for version 0.32.0, this commit fixes this issue.