### PR TITLE
Fix build failure with 0.32.+ version of react-native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.32.0'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:9.4.0"
   compile 'com.google.android.gms:play-services-maps:9.4.0'
 }


### PR DESCRIPTION
___package.json___
```js
{
  [...]
  "dependencies": {
    "react": "^15.3.1",
    "react-native": "^0.32.1",
    "react-native-maps": "^0.8.0"
  }
}
```
---
___error___
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> A problem occurred configuring project ':react-native-maps'.
   > Could not resolve all dependencies for configuration ':react-native-maps:_debugCompile'.
      > Could not find com.facebook.react:react-native:0.32.0.
[...]
```