### PR TITLE
Version 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Change Log
 
-## 0.8.1 (September 8, 2016)
+## 0.8.2 (September 8, 2016)
+
+We realized immediately after publishing 0.8.1 that the NPM package contained
+some test code in the `example2/` directory that contained a copy of the
+`react-native` package, causing this packager error:
+
+```
+Failed to build DependencyGraph: @providesModule naming collision:
+  Duplicate module name: String.prototype.es6
+  Paths: /Users/<path to project>/node_modules/react-native-maps/example2/node_modules/react-native/packager/react-packager/src/Resolver/polyfills/String.prototype.es6.js collides with /Users/<path to project>/node_modules/react-native/packager/react-packager/src/Resolver/polyfills/String.prototype.es6.js
+
+This error is caused by a @providesModule declaration with the same name accross two different files.
+```
+
+0.8.2 is identical to 0.8.1, except with the offending code removed from the NPM package.
+
+
+## 0.8.1 (September 8, 2016) *[DEPRECATED]*
 
 ### Patches
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 VERSION_CODE=2
-VERSION_NAME=0.8.1
+VERSION_NAME=0.8.2
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=React Native Map view component for Android

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React Native Mapview component for iOS + Android",
   "main": "index.js",
   "author": "Leland Richardson <leland.m.richardson@gmail.com>",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "scripts": {
     "start": "react-native start",
     "lint": "eslint ."

--- a/react-native-maps.podspec
+++ b/react-native-maps.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-maps"
-  s.version      = "0.8.1"
+  s.version      = "0.8.2"
   s.summary      = "React Native Mapview component for iOS + Android"
 
   s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }


### PR DESCRIPTION
We realized immediately after publishing 0.8.1 that the NPM package contained some test code in the example2/ directory that contained a copy of the react-native package, causing this packager error:
```
Failed to build DependencyGraph: @providesModule naming collision:
  Duplicate module name: String.prototype.es6
  Paths: /Users/<path to project>/node_modules/react-native-maps/example2/node_modules/react-native/packager/react-packager/src/Resolver/polyfills/String.prototype.es6.js collides with /Users/<path to project>/node_modules/react-native/packager/react-packager/src/Resolver/polyfills/String.prototype.es6.js

This error is caused by a @providesModule declaration with the same name accross two different files.
```

0.8.2 is identical to 0.8.1, except with the offending code removed from the NPM package.

:facepalm:

to: @lelandrichardson @christopherdro @jrichardlai 