### PR TITLE
Don't fit to elements if no positions added

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -497,20 +497,27 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     public void fitToElements(boolean animated) {
         LatLngBounds.Builder builder = new LatLngBounds.Builder();
+
+        boolean addedPosition = false;
+
         for (AirMapFeature feature : features) {
             if (feature instanceof AirMapMarker) {
                 Marker marker = (Marker) feature.getFeature();
                 builder.include(marker.getPosition());
+                addedPosition = true;
             }
             // TODO(lmr): may want to include shapes / etc.
         }
-        LatLngBounds bounds = builder.build();
-        CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, 50);
-        if (animated) {
-            startMonitoringRegion();
-            map.animateCamera(cu);
-        } else {
-            map.moveCamera(cu);
+
+        if (addedPosition) {
+            LatLngBounds bounds = builder.build();
+            CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, 50);
+            if (animated) {
+                startMonitoringRegion();
+                map.animateCamera(cu);
+            } else {
+                map.moveCamera(cu);
+            }
         }
     }
 


### PR DESCRIPTION
This commit prevents the crash mentioned in #180. It is identical to the implementation in `AirMapView#fitToSuppliedMarkers()`.

This doesn't actually fix the issue mentioned in #180 because while the app no longer crashes, the elements aren't zoomed unless you use a setTimeout hack or something similar. @igrayson has written about this there.

It would be great to figure out why that isn't working, however.

